### PR TITLE
Update obtaining-testnet-eth-and-liquid-staking-tokens-lsts.md

### DIFF
--- a/docs/eigenlayer/restaking-guides/0-restaking-user-guide/stage-2-testnet/obtaining-testnet-eth-and-liquid-staking-tokens-lsts.md
+++ b/docs/eigenlayer/restaking-guides/0-restaking-user-guide/stage-2-testnet/obtaining-testnet-eth-and-liquid-staking-tokens-lsts.md
@@ -17,6 +17,7 @@ Before you can use a faucet to load your wallet with testnet ETH, you will need:
 
 Once you have a Holesky compatible wallet and a Holesky ETH address, you can use a faucet to load your wallet with testnet ETH. Here are options available to obtain holETH:
 - [Holešky PoW Faucet](https://holesky-faucet.pk910.de).
+- [Holešky Proof of Machinehood (PoM) Faucet](https://www.holeskyfaucet.io/).
 
 ## Swap holETH for wETH (Wrapped ETH)​
 - Send holETH to address 0x94373a4919B3240D86eA41593D5eBa789FEF3848 .


### PR DESCRIPTION
Introduction of Holesky PoM Faucet as an alternative allowing users to directly claim 1 HolETH per request with Proof of Machinehood (PoM).

The faucet only requires users to provide a valid Holesky ETH address without needing to install a compatible wallet to their system. The request is then simply authenticated by hardware attestation that is generated from the device built-in authenticator, such as Apple FaceID.

For more info, check out the docs at https://docs.ata.network/automata-2.0/proof-of-machinehood